### PR TITLE
Add debezium-avro-glue format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CREATE TABLE user_created (
 )
 ```
 
-## Format Options
+### Format Options
 
 | Option                                  | Required | Forwarded |      Default       |  Type   | Description                                                                |
 |-----------------------------------------|:--------:|:---------:|:------------------:|:-------:|----------------------------------------------------------------------------|
@@ -68,3 +68,31 @@ CREATE TABLE user_created (
 
 Note that all options can be prefixed with `avro-glue.schema.registry` and all camel cased options can be dot
 cased (`avro-glue.schema.auto.registration.enabled` is equivalent to `avro-glue.schemaAutoRegistrationEnabled`).
+
+## Create tables with Debezium-Avro-Glue Format
+
+`debezium-avro-glue` is a wrapper around the `avro-glue` format that allows you to parse Debezium encoded messages. Debezium support is heavily inspired by `debezium-avro-confluent` and `debezium-avro-json` formats.
+
+```
+CREATE TABLE user_created (
+  id            STRING,
+  name          STRING,
+  email         STRING,
+  primary key (id)
+) WITH (
+  'connector'                = 'kafka',
+  'topic'                    = 'user_events',
+  'properties.bootstrap.servers' 
+                             = 'localhost:9092',
+    
+  'format'                   = 'debezium-avro-glue',
+  'avro-glue.schemaName'     = 'org.example.avro.UserEvent'
+  'avro-glue.region'         = 'us-east-1',
+  'avro-glue.registry'       = 'my-glue-registry',
+  'avro-glue.transport.name' = 'user_events'
+)
+```
+
+Format options are the same as the `avro-glue` format.
+
+

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/AvroGlueFormatFactory.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/AvroGlueFormatFactory.java
@@ -168,7 +168,7 @@ public class AvroGlueFormatFactory
 
   @NotNull
   @VisibleForTesting
-  private Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
+  public static Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
     HashMap<String, Object> configs = new HashMap<>();
     configs.put(AWS_REGION.key(), formatOptions.get(AWS_REGION));
     configs.put(SCHEMA_NAME.key(), formatOptions.get(SCHEMA_NAME));

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/AvroGlueFormatFactory.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/AvroGlueFormatFactory.java
@@ -36,153 +36,153 @@ import org.slf4j.LoggerFactory;
  * {@link SerializationSchema} and {@link DeserializationSchema}.
  */
 public class AvroGlueFormatFactory
-        implements DeserializationFormatFactory, SerializationFormatFactory {
+    implements DeserializationFormatFactory, SerializationFormatFactory {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
 
-    public static final String IDENTIFIER = "avro-glue";
+  public static final String IDENTIFIER = "avro-glue";
 
-    @Override
-    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
-            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+  @Override
+  public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+      DynamicTableFactory.Context context, ReadableConfig formatOptions) {
 
-        FactoryUtil.validateFactoryOptions(this, formatOptions);
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
 
-        String schemaName = formatOptions.get(SCHEMA_NAME);
+    String schemaName = formatOptions.get(SCHEMA_NAME);
 
-        Map<String, Object> configs = buildConfigs(formatOptions);
+    Map<String, Object> configs = buildConfigs(formatOptions);
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
-        }
-
-        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
-            @Override
-            public DeserializationSchema<RowData> createRuntimeDecoder(
-                    DynamicTableSource.Context context, DataType producedDataType, int[][] projections) {
-                producedDataType = Projection.of(projections).project(producedDataType);
-                final RowType rowType = (RowType) producedDataType.getLogicalType();
-                final TypeInformation<RowData> rowDataTypeInfo = context.createTypeInformation(producedDataType);
-                return new AvroRowDataDeserializationSchema(
-                        GlueAvroDeserializationSchema.forGeneric(
-                                AvroSchemaConverter.convertToSchema(rowType, schemaName), configs),
-                        AvroToRowDataConverters.createRowConverter(rowType),
-                        rowDataTypeInfo);
-            }
-
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.insertOnly();
-            }
-        };
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
     }
 
-    @Override
-    public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
-            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+    return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
+      @Override
+      public DeserializationSchema<RowData> createRuntimeDecoder(
+          DynamicTableSource.Context context, DataType producedDataType, int[][] projections) {
+        producedDataType = Projection.of(projections).project(producedDataType);
+        final RowType rowType = (RowType) producedDataType.getLogicalType();
+        final TypeInformation<RowData> rowDataTypeInfo = context.createTypeInformation(producedDataType);
+        return new AvroRowDataDeserializationSchema(
+            GlueAvroDeserializationSchema.forGeneric(
+                AvroSchemaConverter.convertToSchema(rowType, schemaName), configs),
+            AvroToRowDataConverters.createRowConverter(rowType),
+            rowDataTypeInfo);
+      }
 
-        FactoryUtil.validateFactoryOptions(this, formatOptions);
+      @Override
+      public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+      }
+    };
+  }
 
-        String topic = context
-                .getConfiguration()
-                .getOptional(KAFKA_TOPIC)
-                .or(() -> formatOptions.getOptional(KAFKA_TOPIC))
-                .orElseThrow(
-                        () -> new ValidationException(
-                                String.format(
-                                        "Kafka topic not found among table %s options",
-                                        context.getObjectIdentifier().asSummaryString())));
+  @Override
+  public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+      DynamicTableFactory.Context context, ReadableConfig formatOptions) {
 
-        String schemaName = formatOptions.get(SCHEMA_NAME);
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
 
-        Map<String, Object> configs = buildConfigs(formatOptions);
+    String topic = context
+        .getConfiguration()
+        .getOptional(KAFKA_TOPIC)
+        .or(() -> formatOptions.getOptional(KAFKA_TOPIC))
+        .orElseThrow(
+            () -> new ValidationException(
+                String.format(
+                    "Kafka topic not found among table %s options",
+                    context.getObjectIdentifier().asSummaryString())));
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "createEncodingFormat() with topic {}, schemaName {} and configs {}",
-                    topic,
-                    schemaName,
-                    configs);
-        }
+    String schemaName = formatOptions.get(SCHEMA_NAME);
 
-        return new EncodingFormat<SerializationSchema<RowData>>() {
-            @Override
-            public SerializationSchema<RowData> createRuntimeEncoder(
-                    DynamicTableSink.Context context, DataType consumedDataType) {
-                final RowType rowType = (RowType) consumedDataType.getLogicalType();
-                return new AvroRowDataSerializationSchema(
-                        rowType,
-                        GlueAvroSerializationSchema.forGeneric(
-                                AvroSchemaConverter.convertToSchema(rowType, schemaName), topic, configs),
-                        RowDataToAvroConverters.createConverter(rowType));
-            }
+    Map<String, Object> configs = buildConfigs(formatOptions);
 
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.insertOnly();
-            }
-        };
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "createEncodingFormat() with topic {}, schemaName {} and configs {}",
+          topic,
+          schemaName,
+          configs);
     }
 
-    @Override
-    public String factoryIdentifier() {
-        return IDENTIFIER;
-    }
+    return new EncodingFormat<SerializationSchema<RowData>>() {
+      @Override
+      public SerializationSchema<RowData> createRuntimeEncoder(
+          DynamicTableSink.Context context, DataType consumedDataType) {
+        final RowType rowType = (RowType) consumedDataType.getLogicalType();
+        return new AvroRowDataSerializationSchema(
+            rowType,
+            GlueAvroSerializationSchema.forGeneric(
+                AvroSchemaConverter.convertToSchema(rowType, schemaName), topic, configs),
+            RowDataToAvroConverters.createConverter(rowType));
+      }
 
-    @Override
-    public Set<ConfigOption<?>> requiredOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(SCHEMA_NAME);
-        return options;
-    }
+      @Override
+      public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+      }
+    };
+  }
 
-    @Override
-    public Set<ConfigOption<?>> optionalOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(KAFKA_TOPIC); // required for our tests, but not otherwise
-        options.add(PROPERTIES);
-        options.add(REGISTRY_NAME);
-        options.add(AWS_REGION);
-        options.add(AWS_ENDPOINT);
-        options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
-        options.add(SCHEMA_NAMING_GENERATION_CLASS);
-        options.add(SECONDARY_DESERIALIZER);
-        return options;
-    }
+  @Override
+  public String factoryIdentifier() {
+    return IDENTIFIER;
+  }
 
-    @Override
-    public Set<ConfigOption<?>> forwardOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(REGISTRY_NAME);
-        options.add(PROPERTIES);
-        options.add(SCHEMA_NAME);
-        options.add(AWS_REGION);
-        options.add(AWS_ENDPOINT);
-        options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
-        options.add(SCHEMA_NAMING_GENERATION_CLASS);
-        options.add(SECONDARY_DESERIALIZER);
-        return options;
-    }
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(SCHEMA_NAME);
+    return options;
+  }
 
-    @NotNull
-    @VisibleForTesting
-    public static Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
-        HashMap<String, Object> configs = new HashMap<>();
-        configs.put(AWS_REGION.key(), formatOptions.get(AWS_REGION));
-        configs.put(SCHEMA_NAME.key(), formatOptions.get(SCHEMA_NAME));
-        formatOptions.getOptional(PROPERTIES).ifPresent(configs::putAll);
-        formatOptions.getOptional(AWS_ENDPOINT).ifPresent(v -> configs.put(AWS_ENDPOINT.key(), v));
-        formatOptions.getOptional(REGISTRY_NAME).ifPresent(v -> configs.put(REGISTRY_NAME.key(), v));
-        formatOptions
-                .getOptional(SCHEMA_AUTO_REGISTRATION_SETTING)
-                .ifPresent(v -> configs.put(SCHEMA_AUTO_REGISTRATION_SETTING.key(), v));
-        formatOptions
-                .getOptional(SCHEMA_NAMING_GENERATION_CLASS)
-                .ifPresent(v -> configs.put(SCHEMA_NAMING_GENERATION_CLASS.key(), v));
-        formatOptions
-                .getOptional(SECONDARY_DESERIALIZER)
-                .ifPresent(v -> configs.put(SECONDARY_DESERIALIZER.key(), v));
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(KAFKA_TOPIC); // required for our tests, but not otherwise
+    options.add(PROPERTIES);
+    options.add(REGISTRY_NAME);
+    options.add(AWS_REGION);
+    options.add(AWS_ENDPOINT);
+    options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
+    options.add(SCHEMA_NAMING_GENERATION_CLASS);
+    options.add(SECONDARY_DESERIALIZER);
+    return options;
+  }
 
-        return configs;
-    }
+  @Override
+  public Set<ConfigOption<?>> forwardOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(REGISTRY_NAME);
+    options.add(PROPERTIES);
+    options.add(SCHEMA_NAME);
+    options.add(AWS_REGION);
+    options.add(AWS_ENDPOINT);
+    options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
+    options.add(SCHEMA_NAMING_GENERATION_CLASS);
+    options.add(SECONDARY_DESERIALIZER);
+    return options;
+  }
+
+  @NotNull
+  @VisibleForTesting
+  public static Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
+    HashMap<String, Object> configs = new HashMap<>();
+    configs.put(AWS_REGION.key(), formatOptions.get(AWS_REGION));
+    configs.put(SCHEMA_NAME.key(), formatOptions.get(SCHEMA_NAME));
+    formatOptions.getOptional(PROPERTIES).ifPresent(configs::putAll);
+    formatOptions.getOptional(AWS_ENDPOINT).ifPresent(v -> configs.put(AWS_ENDPOINT.key(), v));
+    formatOptions.getOptional(REGISTRY_NAME).ifPresent(v -> configs.put(REGISTRY_NAME.key(), v));
+    formatOptions
+        .getOptional(SCHEMA_AUTO_REGISTRATION_SETTING)
+        .ifPresent(v -> configs.put(SCHEMA_AUTO_REGISTRATION_SETTING.key(), v));
+    formatOptions
+        .getOptional(SCHEMA_NAMING_GENERATION_CLASS)
+        .ifPresent(v -> configs.put(SCHEMA_NAMING_GENERATION_CLASS.key(), v));
+    formatOptions
+        .getOptional(SECONDARY_DESERIALIZER)
+        .ifPresent(v -> configs.put(SECONDARY_DESERIALIZER.key(), v));
+
+    return configs;
+  }
 }

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/AvroGlueFormatOptions.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/AvroGlueFormatOptions.java
@@ -11,114 +11,109 @@ public class AvroGlueFormatOptions {
 
   static String dotCase(String name) {
     return name.replaceAll(
-            String.format(
-                "%s|%s|%s",
-                "(?<=[A-Z])(?=[A-Z][a-z])", "(?<=[^A-Z])(?=[A-Z])", "(?<=[A-Za-z])(?=[^A-Za-z])"),
-            ".")
+        String.format(
+            "%s|%s|%s",
+            "(?<=[A-Z])(?=[A-Z][a-z])", "(?<=[^A-Z])(?=[A-Z])", "(?<=[A-Za-z])(?=[^A-Za-z])"),
+        ".")
         .toLowerCase();
   }
 
-  public static final ConfigOption<String> KAFKA_TOPIC =
-      ConfigOptions.key("topic")
-          .stringType()
-          .noDefaultValue()
-          .withDescription(
-              "This is not used as a config for the format, but to pull in the "
-                  + "table kafka connector topic configuration.");
+  public static final ConfigOption<String> KAFKA_TOPIC = ConfigOptions.key("topic")
+      .stringType()
+      .noDefaultValue()
+      .withDescription(
+          "This is not used as a config for the format, but to pull in the "
+              + "table kafka connector topic configuration.");
 
-  public static final ConfigOption<String> SCHEMA_NAME =
-      ConfigOptions.key(AWSSchemaRegistryConstants.SCHEMA_NAME)
-          .stringType()
-          .noDefaultValue()
-          .withFallbackKeys(
-              dotCase(AWSSchemaRegistryConstants.SCHEMA_NAME),
-              "schema.registry." + AWSSchemaRegistryConstants.SCHEMA_NAME,
-              "schema.registry." + dotCase(AWSSchemaRegistryConstants.SCHEMA_NAME))
-          .withDescription(
-              "The schema name to register the schema under. This is required "
-                  + " and should be the same as the avro schema's full name.");
+  public static final ConfigOption<String> SCHEMA_NAME = ConfigOptions.key(AWSSchemaRegistryConstants.SCHEMA_NAME)
+      .stringType()
+      .noDefaultValue()
+      .withFallbackKeys(
+          dotCase(AWSSchemaRegistryConstants.SCHEMA_NAME),
+          "schema.registry." + AWSSchemaRegistryConstants.SCHEMA_NAME,
+          "schema.registry." + dotCase(AWSSchemaRegistryConstants.SCHEMA_NAME))
+      .withDescription(
+          "The schema name to register the schema under. This is required "
+              + " and should be the same as the avro schema's full name.");
 
-  public static final ConfigOption<String> AWS_REGION =
-      ConfigOptions.key(AWSSchemaRegistryConstants.AWS_REGION)
-          .stringType()
-          .defaultValue(Region.US_EAST_1.toString())
-          .withFallbackKeys("aws.region")
-          .withDescription(
-              "The AWS Region your Glue schema registry operates in (defaults "
-                  + "to 'us-east-1').");
+  public static final ConfigOption<String> AWS_REGION = ConfigOptions.key(AWSSchemaRegistryConstants.AWS_REGION)
+      .stringType()
+      .defaultValue(Region.US_EAST_1.toString())
+      .withFallbackKeys("aws.region")
+      .withDescription(
+          "The AWS Region your Glue schema registry operates in (defaults "
+              + "to 'us-east-1').");
 
-  public static final ConfigOption<String> AWS_ENDPOINT =
-      ConfigOptions.key(AWSSchemaRegistryConstants.AWS_ENDPOINT)
-          .stringType()
-          .noDefaultValue()
-          .withFallbackKeys("aws.endpoint")
-          .withDescription(
-              "The AWS Glue endpoint. Normally inferred "
-                  + "automatically from your AWS Region setting, but useful for "
-                  + "testing with localstack.");
+  public static final ConfigOption<String> AWS_ENDPOINT = ConfigOptions.key(AWSSchemaRegistryConstants.AWS_ENDPOINT)
+      .stringType()
+      .noDefaultValue()
+      .withFallbackKeys("aws.endpoint")
+      .withDescription(
+          "The AWS Glue endpoint. Normally inferred "
+              + "automatically from your AWS Region setting, but useful for "
+              + "testing with localstack.");
 
-  public static final ConfigOption<String> REGISTRY_NAME =
-      ConfigOptions.key(AWSSchemaRegistryConstants.REGISTRY_NAME)
-          .stringType()
-          .defaultValue(AWSSchemaRegistryConstants.DEFAULT_REGISTRY_NAME)
-          .withFallbackKeys("schema.registry." + AWSSchemaRegistryConstants.REGISTRY_NAME)
-          .withDescription(
-              "The name of the Glue registry to operate on. "
-                  + "Defaults"
-                  + " to "
-                  + AWSSchemaRegistryConstants.DEFAULT_REGISTRY_NAME
-                  + ".");
+  public static final ConfigOption<String> REGISTRY_NAME = ConfigOptions.key(AWSSchemaRegistryConstants.REGISTRY_NAME)
+      .stringType()
+      .defaultValue(AWSSchemaRegistryConstants.DEFAULT_REGISTRY_NAME)
+      .withFallbackKeys("schema.registry." + AWSSchemaRegistryConstants.REGISTRY_NAME)
+      .withDescription(
+          "The name of the Glue registry to operate on. "
+              + "Defaults"
+              + " to "
+              + AWSSchemaRegistryConstants.DEFAULT_REGISTRY_NAME
+              + ".");
 
-  public static final ConfigOption<String> SCHEMA_AUTO_REGISTRATION_SETTING =
-      ConfigOptions.key(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING)
-          .stringType()
-          .defaultValue("false")
-          .withFallbackKeys(
-              dotCase(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING),
-              "schema.registry." + AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING,
-              "schema.registry."
-                  + dotCase(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING))
-          .withDescription(
-              "If true, schemas missing from the registry will be "
-                  + "auto-registered on serialization. Default is false.");
+  public static final ConfigOption<String> SCHEMA_AUTO_REGISTRATION_SETTING = ConfigOptions
+      .key(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING)
+      .stringType()
+      .defaultValue("false")
+      .withFallbackKeys(
+          dotCase(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING),
+          "schema.registry." + AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING,
+          "schema.registry."
+              + dotCase(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING))
+      .withDescription(
+          "If true, schemas missing from the registry will be "
+              + "auto-registered on serialization. Default is false.");
 
-  public static final ConfigOption<String> SCHEMA_NAMING_GENERATION_CLASS =
-      ConfigOptions.key(AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS)
-          .stringType()
-          .noDefaultValue()
-          .withFallbackKeys(
-              dotCase(AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS),
-              "schema.registry." + AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS,
-              "schema.registry."
-                  + dotCase(AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS))
-          .withDescription(
-              "The name of a class implementing "
-                  + "'AWSSchemaNamingStrategy' that will be used to dynamically "
-                  + "determine the name of the schema for each data object being "
-                  + "serialized.");
-  public static final ConfigOption<String> SECONDARY_DESERIALIZER =
-      ConfigOptions.key(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER)
-          .stringType()
-          .noDefaultValue()
-          .withFallbackKeys(
-              dotCase(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER),
-              "schema.registry." + AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER,
-              "schema.registry." + dotCase(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER))
-          .withDescription(
-              "The class name of a fallback deserializer that will "
-                  + "be used when Glue can't decode a message. Useful for transitioning"
-                  + " from another schema registry, like Confluent.");
+  public static final ConfigOption<String> SCHEMA_NAMING_GENERATION_CLASS = ConfigOptions
+      .key(AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS)
+      .stringType()
+      .noDefaultValue()
+      .withFallbackKeys(
+          dotCase(AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS),
+          "schema.registry." + AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS,
+          "schema.registry."
+              + dotCase(AWSSchemaRegistryConstants.SCHEMA_NAMING_GENERATION_CLASS))
+      .withDescription(
+          "The name of a class implementing "
+              + "'AWSSchemaNamingStrategy' that will be used to dynamically "
+              + "determine the name of the schema for each data object being "
+              + "serialized.");
+  public static final ConfigOption<String> SECONDARY_DESERIALIZER = ConfigOptions
+      .key(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER)
+      .stringType()
+      .noDefaultValue()
+      .withFallbackKeys(
+          dotCase(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER),
+          "schema.registry." + AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER,
+          "schema.registry." + dotCase(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER))
+      .withDescription(
+          "The class name of a fallback deserializer that will "
+              + "be used when Glue can't decode a message. Useful for transitioning"
+              + " from another schema registry, like Confluent.");
 
-  public static final ConfigOption<Map<String, String>> PROPERTIES =
-      ConfigOptions.key("properties")
-          .mapType()
-          .noDefaultValue()
-          .withFallbackKeys("schema.registry.properties")
-          .withDescription(
-              "Properties map that is forwarded to the underlying "
-                  + "schema registry. This is useful for options that are not "
-                  + "officially exposed via Flink config options. However, note that "
-                  + "Flink options have higher precedence.");
+  public static final ConfigOption<Map<String, String>> PROPERTIES = ConfigOptions.key("properties")
+      .mapType()
+      .noDefaultValue()
+      .withFallbackKeys("schema.registry.properties")
+      .withDescription(
+          "Properties map that is forwarded to the underlying "
+              + "schema registry. This is useful for options that are not "
+              + "officially exposed via Flink config options. However, note that "
+              + "Flink options have higher precedence.");
 
-  private AvroGlueFormatOptions() {}
+  private AvroGlueFormatOptions() {
+  }
 }

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueDeserializationSchema.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueDeserializationSchema.java
@@ -1,0 +1,189 @@
+package org.apache.flink.formats.avro.registry.confluent.debezium;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.AvroRowDataDeserializationSchema;
+import org.apache.flink.formats.avro.AvroToRowDataConverters;
+import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroFormatFactory.validateSchemaString;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
+
+/**
+ * Deserialization schema from Debezium Avro to Flink Table/SQL internal data structure {@link
+ * RowData}. The deserialization schema knows Debezium's schema definition and can extract the
+ * database data and convert into {@link RowData} with {@link RowKind}. Deserializes a <code>byte[]
+ * </code> message as a JSON object and reads the specified fields. Failures during deserialization
+ * are forwarded as wrapped IOExceptions.
+ *
+ * @see <a href="https://debezium.io/">Debezium</a>
+ */
+@Internal
+public final class DebeziumAvroGlueDeserializationSchema implements DeserializationSchema<RowData> {
+    private static final long serialVersionUID = 1L;
+
+    /** snapshot read. */
+    private static final String OP_READ = "r";
+    /** insert operation. */
+    private static final String OP_CREATE = "c";
+    /** update operation. */
+    private static final String OP_UPDATE = "u";
+    /** delete operation. */
+    private static final String OP_DELETE = "d";
+
+    private static final String REPLICA_IDENTITY_EXCEPTION =
+            "The \"before\" field of %s message is null, "
+                    + "if you are using Debezium Postgres Connector, "
+                    + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.";
+
+    /** The deserializer to deserialize Debezium Avro data. */
+    private final AvroRowDataDeserializationSchema avroDeserializer;
+
+    /** TypeInformation of the produced {@link RowData}. */
+    private final TypeInformation<RowData> producedTypeInfo;
+
+    public DebeziumAvroGlueDeserializationSchema(
+            RowType rowType,
+            TypeInformation<RowData> producedTypeInfo,
+            String schemaRegistryUrl,
+            @Nullable String schemaString,
+            @Nullable Map<String, ?> registryConfigs) {
+        this.producedTypeInfo = producedTypeInfo;
+        RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
+
+        validateSchemaString(schemaString, debeziumAvroRowType);
+        Schema schema =
+                schemaString == null
+                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType)
+                        : new Parser().parse(schemaString);
+
+        this.avroDeserializer =
+                new AvroRowDataDeserializationSchema(
+                        ConfluentRegistryAvroDeserializationSchema.forGeneric(
+                                schema, schemaRegistryUrl, registryConfigs),
+                        AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
+                        producedTypeInfo);
+    }
+
+    @VisibleForTesting
+    DebeziumAvroDeserializationSchema(
+            TypeInformation<RowData> producedTypeInfo,
+            AvroRowDataDeserializationSchema avroDeserializer) {
+        this.producedTypeInfo = producedTypeInfo;
+        this.avroDeserializer = avroDeserializer;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        avroDeserializer.open(context);
+    }
+
+    @Override
+    public RowData deserialize(byte[] message) throws IOException {
+        throw new RuntimeException(
+                "Please invoke DeserializationSchema#deserialize(byte[], Collector<RowData>) instead.");
+    }
+
+    @Override
+    public void deserialize(byte[] message, Collector<RowData> out) throws IOException {
+
+        if (message == null || message.length == 0) {
+            // skip tombstone messages
+            return;
+        }
+        try {
+            GenericRowData row = (GenericRowData) avroDeserializer.deserialize(message);
+
+            GenericRowData before = (GenericRowData) row.getField(0);
+            GenericRowData after = (GenericRowData) row.getField(1);
+            String op = row.getField(2).toString();
+            if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
+                after.setRowKind(RowKind.INSERT);
+                out.collect(after);
+            } else if (OP_UPDATE.equals(op)) {
+                if (before == null) {
+                    throw new IllegalStateException(
+                            String.format(REPLICA_IDENTITY_EXCEPTION, "UPDATE"));
+                }
+                before.setRowKind(RowKind.UPDATE_BEFORE);
+                after.setRowKind(RowKind.UPDATE_AFTER);
+                out.collect(before);
+                out.collect(after);
+            } else if (OP_DELETE.equals(op)) {
+                if (before == null) {
+                    throw new IllegalStateException(
+                            String.format(REPLICA_IDENTITY_EXCEPTION, "DELETE"));
+                }
+                before.setRowKind(RowKind.DELETE);
+                out.collect(before);
+            } else {
+                throw new IOException(
+                        format(
+                                "Unknown \"op\" value \"%s\". The Debezium Avro message is '%s'",
+                                op, new String(message)));
+            }
+        } catch (Throwable t) {
+            // a big try catch to protect the processing.
+            throw new IOException("Can't deserialize Debezium Avro message.", t);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return producedTypeInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DebeziumAvroDeserializationSchema that = (DebeziumAvroDeserializationSchema) o;
+        return Objects.equals(avroDeserializer, that.avroDeserializer)
+                && Objects.equals(producedTypeInfo, that.producedTypeInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(avroDeserializer, producedTypeInfo);
+    }
+
+    public static RowType createDebeziumAvroRowType(DataType databaseSchema) {
+        // Debezium Avro contains other information, e.g. "source", "ts_ms"
+        // but we don't need them
+        return (RowType)
+                DataTypes.ROW(
+                                DataTypes.FIELD("before", databaseSchema.nullable()),
+                                DataTypes.FIELD("after", databaseSchema.nullable()),
+                                DataTypes.FIELD("op", DataTypes.STRING()))
+                        .getLogicalType();
+    }
+}

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueDeserializationSchema.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueDeserializationSchema.java
@@ -41,140 +41,140 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDa
  */
 @Internal
 public final class DebeziumAvroGlueDeserializationSchema implements DeserializationSchema<RowData> {
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    /** snapshot read. */
-    private static final String OP_READ = "r";
-    /** insert operation. */
-    private static final String OP_CREATE = "c";
-    /** update operation. */
-    private static final String OP_UPDATE = "u";
-    /** delete operation. */
-    private static final String OP_DELETE = "d";
+  /** snapshot read. */
+  private static final String OP_READ = "r";
+  /** insert operation. */
+  private static final String OP_CREATE = "c";
+  /** update operation. */
+  private static final String OP_UPDATE = "u";
+  /** delete operation. */
+  private static final String OP_DELETE = "d";
 
-    private static final String REPLICA_IDENTITY_EXCEPTION = "The \"before\" field of %s message is null, "
-            + "if you are using Debezium Postgres Connector, "
-            + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.";
+  private static final String REPLICA_IDENTITY_EXCEPTION = "The \"before\" field of %s message is null, "
+      + "if you are using Debezium Postgres Connector, "
+      + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.";
 
-    /** The deserializer to deserialize Debezium Avro data. */
-    private final AvroRowDataDeserializationSchema avroDeserializer;
+  /** The deserializer to deserialize Debezium Avro data. */
+  private final AvroRowDataDeserializationSchema avroDeserializer;
 
-    /** TypeInformation of the produced {@link RowData}. */
-    private final TypeInformation<RowData> producedTypeInfo;
+  /** TypeInformation of the produced {@link RowData}. */
+  private final TypeInformation<RowData> producedTypeInfo;
 
-    public DebeziumAvroGlueDeserializationSchema(
-            RowType rowType,
-            TypeInformation<RowData> producedTypeInfo,
-            String schemaName,
-            Map<String, Object> config) {
-        this.producedTypeInfo = producedTypeInfo;
+  public DebeziumAvroGlueDeserializationSchema(
+      RowType rowType,
+      TypeInformation<RowData> producedTypeInfo,
+      String schemaName,
+      Map<String, Object> config) {
+    this.producedTypeInfo = producedTypeInfo;
 
-        RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
-        Schema debeziumAvroSchema = AvroSchemaConverter.convertToSchema(debeziumAvroRowType, schemaName);
-        this.avroDeserializer = new AvroRowDataDeserializationSchema(
-                GlueAvroDeserializationSchema.forGeneric(debeziumAvroSchema, config),
-                AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
-                producedTypeInfo);
+    RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
+    Schema debeziumAvroSchema = AvroSchemaConverter.convertToSchema(debeziumAvroRowType, schemaName);
+    this.avroDeserializer = new AvroRowDataDeserializationSchema(
+        GlueAvroDeserializationSchema.forGeneric(debeziumAvroSchema, config),
+        AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
+        producedTypeInfo);
+  }
+
+  @VisibleForTesting
+  DebeziumAvroGlueDeserializationSchema(
+      TypeInformation<RowData> producedTypeInfo,
+      AvroRowDataDeserializationSchema avroDeserializer) {
+    this.producedTypeInfo = producedTypeInfo;
+    this.avroDeserializer = avroDeserializer;
+  }
+
+  @Override
+  public void open(InitializationContext context) throws Exception {
+    avroDeserializer.open(context);
+  }
+
+  @Override
+  public RowData deserialize(byte[] message) throws IOException {
+    throw new RuntimeException(
+        "Please invoke DeserializationSchema#deserialize(byte[], Collector<RowData>) instead.");
+  }
+
+  @Override
+  public void deserialize(byte[] message, Collector<RowData> out) throws IOException {
+
+    if (message == null || message.length == 0) {
+      // skip tombstone messages
+      return;
     }
+    try {
+      GenericRowData row = (GenericRowData) avroDeserializer.deserialize(message);
 
-    @VisibleForTesting
-    DebeziumAvroGlueDeserializationSchema(
-            TypeInformation<RowData> producedTypeInfo,
-            AvroRowDataDeserializationSchema avroDeserializer) {
-        this.producedTypeInfo = producedTypeInfo;
-        this.avroDeserializer = avroDeserializer;
-    }
-
-    @Override
-    public void open(InitializationContext context) throws Exception {
-        avroDeserializer.open(context);
-    }
-
-    @Override
-    public RowData deserialize(byte[] message) throws IOException {
-        throw new RuntimeException(
-                "Please invoke DeserializationSchema#deserialize(byte[], Collector<RowData>) instead.");
-    }
-
-    @Override
-    public void deserialize(byte[] message, Collector<RowData> out) throws IOException {
-
-        if (message == null || message.length == 0) {
-            // skip tombstone messages
-            return;
+      GenericRowData before = (GenericRowData) row.getField(0);
+      GenericRowData after = (GenericRowData) row.getField(1);
+      String op = row.getField(2).toString();
+      if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
+        after.setRowKind(RowKind.INSERT);
+        out.collect(after);
+      } else if (OP_UPDATE.equals(op)) {
+        if (before == null) {
+          throw new IllegalStateException(
+              String.format(REPLICA_IDENTITY_EXCEPTION, "UPDATE"));
         }
-        try {
-            GenericRowData row = (GenericRowData) avroDeserializer.deserialize(message);
-
-            GenericRowData before = (GenericRowData) row.getField(0);
-            GenericRowData after = (GenericRowData) row.getField(1);
-            String op = row.getField(2).toString();
-            if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
-                after.setRowKind(RowKind.INSERT);
-                out.collect(after);
-            } else if (OP_UPDATE.equals(op)) {
-                if (before == null) {
-                    throw new IllegalStateException(
-                            String.format(REPLICA_IDENTITY_EXCEPTION, "UPDATE"));
-                }
-                before.setRowKind(RowKind.UPDATE_BEFORE);
-                after.setRowKind(RowKind.UPDATE_AFTER);
-                out.collect(before);
-                out.collect(after);
-            } else if (OP_DELETE.equals(op)) {
-                if (before == null) {
-                    throw new IllegalStateException(
-                            String.format(REPLICA_IDENTITY_EXCEPTION, "DELETE"));
-                }
-                before.setRowKind(RowKind.DELETE);
-                out.collect(before);
-            } else {
-                throw new IOException(
-                        format(
-                                "Unknown \"op\" value \"%s\". The Debezium Avro message is '%s'",
-                                op, new String(message)));
-            }
-        } catch (Throwable t) {
-            // a big try catch to protect the processing.
-            throw new IOException("Can't deserialize Debezium Avro message.", t);
+        before.setRowKind(RowKind.UPDATE_BEFORE);
+        after.setRowKind(RowKind.UPDATE_AFTER);
+        out.collect(before);
+        out.collect(after);
+      } else if (OP_DELETE.equals(op)) {
+        if (before == null) {
+          throw new IllegalStateException(
+              String.format(REPLICA_IDENTITY_EXCEPTION, "DELETE"));
         }
+        before.setRowKind(RowKind.DELETE);
+        out.collect(before);
+      } else {
+        throw new IOException(
+            format(
+                "Unknown \"op\" value \"%s\". The Debezium Avro message is '%s'",
+                op, new String(message)));
+      }
+    } catch (Throwable t) {
+      // a big try catch to protect the processing.
+      throw new IOException("Can't deserialize Debezium Avro message.", t);
     }
+  }
 
-    @Override
-    public boolean isEndOfStream(RowData nextElement) {
-        return false;
-    }
+  @Override
+  public boolean isEndOfStream(RowData nextElement) {
+    return false;
+  }
 
-    @Override
-    public TypeInformation<RowData> getProducedType() {
-        return producedTypeInfo;
-    }
+  @Override
+  public TypeInformation<RowData> getProducedType() {
+    return producedTypeInfo;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DebeziumAvroGlueDeserializationSchema that = (DebeziumAvroGlueDeserializationSchema) o;
-        return Objects.equals(avroDeserializer, that.avroDeserializer)
-                && Objects.equals(producedTypeInfo, that.producedTypeInfo);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DebeziumAvroGlueDeserializationSchema that = (DebeziumAvroGlueDeserializationSchema) o;
+    return Objects.equals(avroDeserializer, that.avroDeserializer)
+        && Objects.equals(producedTypeInfo, that.producedTypeInfo);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(avroDeserializer, producedTypeInfo);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(avroDeserializer, producedTypeInfo);
+  }
 
-    public static RowType createDebeziumAvroRowType(DataType databaseSchema) {
-        // Debezium Avro contains other information, e.g. "source", "ts_ms"
-        // but we don't need them
-        return (RowType) DataTypes.ROW(
-                DataTypes.FIELD("before", databaseSchema.nullable()),
-                DataTypes.FIELD("after", databaseSchema.nullable()),
-                DataTypes.FIELD("op", DataTypes.STRING()))
-                .getLogicalType();
-    }
+  public static RowType createDebeziumAvroRowType(DataType databaseSchema) {
+    // Debezium Avro contains other information, e.g. "source", "ts_ms"
+    // but we don't need them
+    return (RowType) DataTypes.ROW(
+        DataTypes.FIELD("before", databaseSchema.nullable()),
+        DataTypes.FIELD("after", databaseSchema.nullable()),
+        DataTypes.FIELD("op", DataTypes.STRING()))
+        .getLogicalType();
+  }
 }

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactory.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactory.java
@@ -1,0 +1,164 @@
+package io.epiphanous.flink.formats.avro.registry.glue.debezium;
+
+import java.util.Map;
+import static io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatOptions.*;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatFactory;
+
+public class DebeziumAvroGlueFormatFactory implements DeserializationFormatFactory, SerializationFormatFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
+
+  public static final String IDENTIFIER = "debezium-avro-glue";
+
+  @Override
+  public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+      DynamicTableFactory.Context context,
+      ReadableConfig formatOptions) {
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
+
+    String schemaName = formatOptions.get(SCHEMA_NAME);
+
+    // AvroGlueFormatFactory.buildConfigs changed from private to public static
+    Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
+
+    // TODO: Add logging?
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
+    }
+
+    return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
+      @Override
+      public DeserializationSchema<RowData> createRuntimeDecoder(
+          DynamicTableSource.Context context,
+          DataType producedDataType,
+          int[][] projections) {
+        producedDataType = Projection.of(projections).project(producedDataType);
+        final RowType rowType = (RowType) producedDataType.getLogicalType();
+        final TypeInformation<RowData> producedTypeInfo = context.createTypeInformation(producedDataType);
+        return new DebeziumAvroGlueDeserializationSchema(
+          rowType,
+          producedTypeInfo,
+          schemaRegistryURL,
+          schema,
+          optionalPropertiesMap
+        );
+      }
+
+      @Override
+      public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+            .addContainedKind(RowKind.INSERT)
+            .addContainedKind(RowKind.UPDATE_BEFORE)
+            .addContainedKind(RowKind.UPDATE_AFTER)
+            .addContainedKind(RowKind.DELETE)
+            .build();
+      }
+    };
+  }
+
+  @Override
+  public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+      DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
+    String schemaRegistryURL = formatOptions.get(URL);
+    Optional<String> subject = formatOptions.getOptional(SUBJECT);
+    String schema = formatOptions.getOptional(SCHEMA).orElse(null);
+    Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
+
+    if (!subject.isPresent()) {
+      throw new ValidationException(
+          String.format(
+              "Option '%s.%s' is required for serialization",
+              IDENTIFIER, SUBJECT.key()));
+    }
+
+    return new EncodingFormat<SerializationSchema<RowData>>() {
+      @Override
+      public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+            .addContainedKind(RowKind.INSERT)
+            .addContainedKind(RowKind.UPDATE_BEFORE)
+            .addContainedKind(RowKind.UPDATE_AFTER)
+            .addContainedKind(RowKind.DELETE)
+            .build();
+      }
+
+      @Override
+      public SerializationSchema<RowData> createRuntimeEncoder(
+          DynamicTableSink.Context context, DataType consumedDataType) {
+        final RowType rowType = (RowType) consumedDataType.getLogicalType();
+        return new DebeziumAvroSerializationSchema(
+            rowType, schemaRegistryURL, subject.get(), schema, optionalPropertiesMap);
+      }
+    };
+  }
+
+  @Override
+  public String factoryIdentifier() {
+    return IDENTIFIER;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(URL);
+    return options;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(SUBJECT);
+    options.add(PROPERTIES);
+    options.add(SCHEMA);
+    options.add(SSL_KEYSTORE_LOCATION);
+    options.add(SSL_KEYSTORE_PASSWORD);
+    options.add(SSL_TRUSTSTORE_LOCATION);
+    options.add(SSL_TRUSTSTORE_PASSWORD);
+    options.add(BASIC_AUTH_CREDENTIALS_SOURCE);
+    options.add(BASIC_AUTH_USER_INFO);
+    options.add(BEARER_AUTH_CREDENTIALS_SOURCE);
+    options.add(BEARER_AUTH_TOKEN);
+    return options;
+  }
+
+  static void validateSchemaString(@Nullable String schemaString, RowType rowType) {
+    if (schemaString != null) {
+      LogicalType convertedDataType = AvroSchemaConverter.convertToDataType(schemaString).getLogicalType();
+
+      if (!convertedDataType.equals(rowType)) {
+        throw new IllegalArgumentException(
+            format(
+                "Schema provided for '%s' format must be a nullable record type with fields 'before', 'after', 'op'"
+                    + " and schema of fields 'before' and 'after' must match the table schema: %s",
+                IDENTIFIER, schemaString));
+      }
+    }
+  }
+}

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactory.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactory.java
@@ -1,14 +1,21 @@
 package io.epiphanous.flink.formats.avro.registry.glue.debezium;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
 import static io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatOptions.*;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
@@ -31,134 +38,163 @@ import io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatFactory;
 
 public class DebeziumAvroGlueFormatFactory implements DeserializationFormatFactory, SerializationFormatFactory {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
 
-  public static final String IDENTIFIER = "debezium-avro-glue";
+    public static final String IDENTIFIER = "debezium-avro-glue";
 
-  @Override
-  public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
-      DynamicTableFactory.Context context,
-      ReadableConfig formatOptions) {
-    FactoryUtil.validateFactoryOptions(this, formatOptions);
+    @Override
+    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+            DynamicTableFactory.Context context,
+            ReadableConfig formatOptions) {
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
 
-    String schemaName = formatOptions.get(SCHEMA_NAME);
+        String schemaName = formatOptions.get(SCHEMA_NAME);
 
-    // AvroGlueFormatFactory.buildConfigs changed from private to public static
-    Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
+        // AvroGlueFormatFactory.buildConfigs changed from private to public static
+        Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
 
-    // TODO: Add logging?
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
+        }
+
+        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
+            @Override
+            public DeserializationSchema<RowData> createRuntimeDecoder(
+                    DynamicTableSource.Context context,
+                    DataType producedDataType,
+                    int[][] projections) {
+                producedDataType = Projection.of(projections).project(producedDataType);
+                final RowType rowType = (RowType) producedDataType.getLogicalType();
+                final TypeInformation<RowData> producedTypeInfo = context.createTypeInformation(producedDataType);
+                return new DebeziumAvroGlueDeserializationSchema(
+                        rowType,
+                        producedTypeInfo,
+                        schemaName,
+                        configs);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.UPDATE_BEFORE)
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+            }
+        };
     }
 
-    return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
-      @Override
-      public DeserializationSchema<RowData> createRuntimeDecoder(
-          DynamicTableSource.Context context,
-          DataType producedDataType,
-          int[][] projections) {
-        producedDataType = Projection.of(projections).project(producedDataType);
-        final RowType rowType = (RowType) producedDataType.getLogicalType();
-        final TypeInformation<RowData> producedTypeInfo = context.createTypeInformation(producedDataType);
-        return new DebeziumAvroGlueDeserializationSchema(
-          rowType,
-          producedTypeInfo,
-          schemaRegistryURL,
-          schema,
-          optionalPropertiesMap
-        );
-      }
+    @Override
+    public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
 
-      @Override
-      public ChangelogMode getChangelogMode() {
-        return ChangelogMode.newBuilder()
-            .addContainedKind(RowKind.INSERT)
-            .addContainedKind(RowKind.UPDATE_BEFORE)
-            .addContainedKind(RowKind.UPDATE_AFTER)
-            .addContainedKind(RowKind.DELETE)
-            .build();
-      }
-    };
-  }
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
 
-  @Override
-  public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
-      DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        String topic = context
+                .getConfiguration()
+                .getOptional(KAFKA_TOPIC)
+                .or(() -> formatOptions.getOptional(KAFKA_TOPIC))
+                .orElseThrow(
+                        () -> new ValidationException(
+                                String.format(
+                                        "Kafka topic not found among table %s options",
+                                        context.getObjectIdentifier().asSummaryString())));
 
-    FactoryUtil.validateFactoryOptions(this, formatOptions);
-    String schemaRegistryURL = formatOptions.get(URL);
-    Optional<String> subject = formatOptions.getOptional(SUBJECT);
-    String schema = formatOptions.getOptional(SCHEMA).orElse(null);
-    Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
+        String schemaName = formatOptions.get(SCHEMA_NAME);
 
-    if (!subject.isPresent()) {
-      throw new ValidationException(
-          String.format(
-              "Option '%s.%s' is required for serialization",
-              IDENTIFIER, SUBJECT.key()));
+        Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "createEncodingFormat() with topic {}, schemaName {} and configs {}",
+                    topic,
+                    schemaName,
+                    configs);
+        }
+
+        return new EncodingFormat<SerializationSchema<RowData>>() {
+            @Override
+            public SerializationSchema<RowData> createRuntimeEncoder(
+                    DynamicTableSink.Context context, DataType consumedDataType) {
+                final RowType rowType = (RowType) consumedDataType.getLogicalType();
+                return new DebeziumAvroGlueSerializationSchema(
+                        rowType,
+                        schemaName,
+                        configs);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.UPDATE_BEFORE)
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+            }
+        };
     }
 
-    return new EncodingFormat<SerializationSchema<RowData>>() {
-      @Override
-      public ChangelogMode getChangelogMode() {
-        return ChangelogMode.newBuilder()
-            .addContainedKind(RowKind.INSERT)
-            .addContainedKind(RowKind.UPDATE_BEFORE)
-            .addContainedKind(RowKind.UPDATE_AFTER)
-            .addContainedKind(RowKind.DELETE)
-            .build();
-      }
-
-      @Override
-      public SerializationSchema<RowData> createRuntimeEncoder(
-          DynamicTableSink.Context context, DataType consumedDataType) {
-        final RowType rowType = (RowType) consumedDataType.getLogicalType();
-        return new DebeziumAvroSerializationSchema(
-            rowType, schemaRegistryURL, subject.get(), schema, optionalPropertiesMap);
-      }
-    };
-  }
-
-  @Override
-  public String factoryIdentifier() {
-    return IDENTIFIER;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> requiredOptions() {
-    Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(URL);
-    return options;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> optionalOptions() {
-    Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(SUBJECT);
-    options.add(PROPERTIES);
-    options.add(SCHEMA);
-    options.add(SSL_KEYSTORE_LOCATION);
-    options.add(SSL_KEYSTORE_PASSWORD);
-    options.add(SSL_TRUSTSTORE_LOCATION);
-    options.add(SSL_TRUSTSTORE_PASSWORD);
-    options.add(BASIC_AUTH_CREDENTIALS_SOURCE);
-    options.add(BASIC_AUTH_USER_INFO);
-    options.add(BEARER_AUTH_CREDENTIALS_SOURCE);
-    options.add(BEARER_AUTH_TOKEN);
-    return options;
-  }
-
-  static void validateSchemaString(@Nullable String schemaString, RowType rowType) {
-    if (schemaString != null) {
-      LogicalType convertedDataType = AvroSchemaConverter.convertToDataType(schemaString).getLogicalType();
-
-      if (!convertedDataType.equals(rowType)) {
-        throw new IllegalArgumentException(
-            format(
-                "Schema provided for '%s' format must be a nullable record type with fields 'before', 'after', 'op'"
-                    + " and schema of fields 'before' and 'after' must match the table schema: %s",
-                IDENTIFIER, schemaString));
-      }
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
     }
-  }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(SCHEMA_NAME);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(KAFKA_TOPIC); // required for our tests, but not otherwise
+        options.add(PROPERTIES);
+        options.add(REGISTRY_NAME);
+        options.add(AWS_REGION);
+        options.add(AWS_ENDPOINT);
+        options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
+        options.add(SCHEMA_NAMING_GENERATION_CLASS);
+        options.add(SECONDARY_DESERIALIZER);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(REGISTRY_NAME);
+        options.add(PROPERTIES);
+        options.add(SCHEMA_NAME);
+        options.add(AWS_REGION);
+        options.add(AWS_ENDPOINT);
+        options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
+        options.add(SCHEMA_NAMING_GENERATION_CLASS);
+        options.add(SECONDARY_DESERIALIZER);
+        return options;
+    }
+
+    @NotNull
+    @VisibleForTesting
+    public static Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put(AWS_REGION.key(), formatOptions.get(AWS_REGION));
+        configs.put(SCHEMA_NAME.key(), formatOptions.get(SCHEMA_NAME));
+        formatOptions.getOptional(PROPERTIES).ifPresent(configs::putAll);
+        formatOptions.getOptional(AWS_ENDPOINT).ifPresent(v -> configs.put(AWS_ENDPOINT.key(), v));
+        formatOptions.getOptional(REGISTRY_NAME).ifPresent(v -> configs.put(REGISTRY_NAME.key(), v));
+        formatOptions
+                .getOptional(SCHEMA_AUTO_REGISTRATION_SETTING)
+                .ifPresent(v -> configs.put(SCHEMA_AUTO_REGISTRATION_SETTING.key(), v));
+        formatOptions
+                .getOptional(SCHEMA_NAMING_GENERATION_CLASS)
+                .ifPresent(v -> configs.put(SCHEMA_NAMING_GENERATION_CLASS.key(), v));
+        formatOptions
+                .getOptional(SECONDARY_DESERIALIZER)
+                .ifPresent(v -> configs.put(SECONDARY_DESERIALIZER.key(), v));
+
+        return configs;
+    }
 }

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactory.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactory.java
@@ -38,163 +38,163 @@ import io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatFactory;
 
 public class DebeziumAvroGlueFormatFactory implements DeserializationFormatFactory, SerializationFormatFactory {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AvroGlueFormatFactory.class);
 
-    public static final String IDENTIFIER = "debezium-avro-glue";
+  public static final String IDENTIFIER = "debezium-avro-glue";
 
-    @Override
-    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
-            DynamicTableFactory.Context context,
-            ReadableConfig formatOptions) {
-        FactoryUtil.validateFactoryOptions(this, formatOptions);
+  @Override
+  public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+      DynamicTableFactory.Context context,
+      ReadableConfig formatOptions) {
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
 
-        String schemaName = formatOptions.get(SCHEMA_NAME);
+    String schemaName = formatOptions.get(SCHEMA_NAME);
 
-        // AvroGlueFormatFactory.buildConfigs changed from private to public static
-        Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
+    // AvroGlueFormatFactory.buildConfigs changed from private to public static
+    Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
-        }
-
-        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
-            @Override
-            public DeserializationSchema<RowData> createRuntimeDecoder(
-                    DynamicTableSource.Context context,
-                    DataType producedDataType,
-                    int[][] projections) {
-                producedDataType = Projection.of(projections).project(producedDataType);
-                final RowType rowType = (RowType) producedDataType.getLogicalType();
-                final TypeInformation<RowData> producedTypeInfo = context.createTypeInformation(producedDataType);
-                return new DebeziumAvroGlueDeserializationSchema(
-                        rowType,
-                        producedTypeInfo,
-                        schemaName,
-                        configs);
-            }
-
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.newBuilder()
-                        .addContainedKind(RowKind.INSERT)
-                        .addContainedKind(RowKind.UPDATE_BEFORE)
-                        .addContainedKind(RowKind.UPDATE_AFTER)
-                        .addContainedKind(RowKind.DELETE)
-                        .build();
-            }
-        };
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("createDecodingFormat() with schemaName {} and configs {}", schemaName, configs);
     }
 
-    @Override
-    public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
-            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+    return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
+      @Override
+      public DeserializationSchema<RowData> createRuntimeDecoder(
+          DynamicTableSource.Context context,
+          DataType producedDataType,
+          int[][] projections) {
+        producedDataType = Projection.of(projections).project(producedDataType);
+        final RowType rowType = (RowType) producedDataType.getLogicalType();
+        final TypeInformation<RowData> producedTypeInfo = context.createTypeInformation(producedDataType);
+        return new DebeziumAvroGlueDeserializationSchema(
+            rowType,
+            producedTypeInfo,
+            schemaName,
+            configs);
+      }
 
-        FactoryUtil.validateFactoryOptions(this, formatOptions);
+      @Override
+      public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+            .addContainedKind(RowKind.INSERT)
+            .addContainedKind(RowKind.UPDATE_BEFORE)
+            .addContainedKind(RowKind.UPDATE_AFTER)
+            .addContainedKind(RowKind.DELETE)
+            .build();
+      }
+    };
+  }
 
-        String topic = context
-                .getConfiguration()
-                .getOptional(KAFKA_TOPIC)
-                .or(() -> formatOptions.getOptional(KAFKA_TOPIC))
-                .orElseThrow(
-                        () -> new ValidationException(
-                                String.format(
-                                        "Kafka topic not found among table %s options",
-                                        context.getObjectIdentifier().asSummaryString())));
+  @Override
+  public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+      DynamicTableFactory.Context context, ReadableConfig formatOptions) {
 
-        String schemaName = formatOptions.get(SCHEMA_NAME);
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
 
-        Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
+    String topic = context
+        .getConfiguration()
+        .getOptional(KAFKA_TOPIC)
+        .or(() -> formatOptions.getOptional(KAFKA_TOPIC))
+        .orElseThrow(
+            () -> new ValidationException(
+                String.format(
+                    "Kafka topic not found among table %s options",
+                    context.getObjectIdentifier().asSummaryString())));
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "createEncodingFormat() with topic {}, schemaName {} and configs {}",
-                    topic,
-                    schemaName,
-                    configs);
-        }
+    String schemaName = formatOptions.get(SCHEMA_NAME);
 
-        return new EncodingFormat<SerializationSchema<RowData>>() {
-            @Override
-            public SerializationSchema<RowData> createRuntimeEncoder(
-                    DynamicTableSink.Context context, DataType consumedDataType) {
-                final RowType rowType = (RowType) consumedDataType.getLogicalType();
-                return new DebeziumAvroGlueSerializationSchema(
-                        rowType,
-                        schemaName,
-                        configs);
-            }
+    Map<String, Object> configs = AvroGlueFormatFactory.buildConfigs(formatOptions);
 
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.newBuilder()
-                        .addContainedKind(RowKind.INSERT)
-                        .addContainedKind(RowKind.UPDATE_BEFORE)
-                        .addContainedKind(RowKind.UPDATE_AFTER)
-                        .addContainedKind(RowKind.DELETE)
-                        .build();
-            }
-        };
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "createEncodingFormat() with topic {}, schemaName {} and configs {}",
+          topic,
+          schemaName,
+          configs);
     }
 
-    @Override
-    public String factoryIdentifier() {
-        return IDENTIFIER;
-    }
+    return new EncodingFormat<SerializationSchema<RowData>>() {
+      @Override
+      public SerializationSchema<RowData> createRuntimeEncoder(
+          DynamicTableSink.Context context, DataType consumedDataType) {
+        final RowType rowType = (RowType) consumedDataType.getLogicalType();
+        return new DebeziumAvroGlueSerializationSchema(
+            rowType,
+            schemaName,
+            configs);
+      }
 
-    @Override
-    public Set<ConfigOption<?>> requiredOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(SCHEMA_NAME);
-        return options;
-    }
+      @Override
+      public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+            .addContainedKind(RowKind.INSERT)
+            .addContainedKind(RowKind.UPDATE_BEFORE)
+            .addContainedKind(RowKind.UPDATE_AFTER)
+            .addContainedKind(RowKind.DELETE)
+            .build();
+      }
+    };
+  }
 
-    @Override
-    public Set<ConfigOption<?>> optionalOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(KAFKA_TOPIC); // required for our tests, but not otherwise
-        options.add(PROPERTIES);
-        options.add(REGISTRY_NAME);
-        options.add(AWS_REGION);
-        options.add(AWS_ENDPOINT);
-        options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
-        options.add(SCHEMA_NAMING_GENERATION_CLASS);
-        options.add(SECONDARY_DESERIALIZER);
-        return options;
-    }
+  @Override
+  public String factoryIdentifier() {
+    return IDENTIFIER;
+  }
 
-    @Override
-    public Set<ConfigOption<?>> forwardOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(REGISTRY_NAME);
-        options.add(PROPERTIES);
-        options.add(SCHEMA_NAME);
-        options.add(AWS_REGION);
-        options.add(AWS_ENDPOINT);
-        options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
-        options.add(SCHEMA_NAMING_GENERATION_CLASS);
-        options.add(SECONDARY_DESERIALIZER);
-        return options;
-    }
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(SCHEMA_NAME);
+    return options;
+  }
 
-    @NotNull
-    @VisibleForTesting
-    public static Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
-        HashMap<String, Object> configs = new HashMap<>();
-        configs.put(AWS_REGION.key(), formatOptions.get(AWS_REGION));
-        configs.put(SCHEMA_NAME.key(), formatOptions.get(SCHEMA_NAME));
-        formatOptions.getOptional(PROPERTIES).ifPresent(configs::putAll);
-        formatOptions.getOptional(AWS_ENDPOINT).ifPresent(v -> configs.put(AWS_ENDPOINT.key(), v));
-        formatOptions.getOptional(REGISTRY_NAME).ifPresent(v -> configs.put(REGISTRY_NAME.key(), v));
-        formatOptions
-                .getOptional(SCHEMA_AUTO_REGISTRATION_SETTING)
-                .ifPresent(v -> configs.put(SCHEMA_AUTO_REGISTRATION_SETTING.key(), v));
-        formatOptions
-                .getOptional(SCHEMA_NAMING_GENERATION_CLASS)
-                .ifPresent(v -> configs.put(SCHEMA_NAMING_GENERATION_CLASS.key(), v));
-        formatOptions
-                .getOptional(SECONDARY_DESERIALIZER)
-                .ifPresent(v -> configs.put(SECONDARY_DESERIALIZER.key(), v));
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(KAFKA_TOPIC); // required for our tests, but not otherwise
+    options.add(PROPERTIES);
+    options.add(REGISTRY_NAME);
+    options.add(AWS_REGION);
+    options.add(AWS_ENDPOINT);
+    options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
+    options.add(SCHEMA_NAMING_GENERATION_CLASS);
+    options.add(SECONDARY_DESERIALIZER);
+    return options;
+  }
 
-        return configs;
-    }
+  @Override
+  public Set<ConfigOption<?>> forwardOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(REGISTRY_NAME);
+    options.add(PROPERTIES);
+    options.add(SCHEMA_NAME);
+    options.add(AWS_REGION);
+    options.add(AWS_ENDPOINT);
+    options.add(SCHEMA_AUTO_REGISTRATION_SETTING);
+    options.add(SCHEMA_NAMING_GENERATION_CLASS);
+    options.add(SECONDARY_DESERIALIZER);
+    return options;
+  }
+
+  @NotNull
+  @VisibleForTesting
+  public static Map<String, Object> buildConfigs(ReadableConfig formatOptions) {
+    HashMap<String, Object> configs = new HashMap<>();
+    configs.put(AWS_REGION.key(), formatOptions.get(AWS_REGION));
+    configs.put(SCHEMA_NAME.key(), formatOptions.get(SCHEMA_NAME));
+    formatOptions.getOptional(PROPERTIES).ifPresent(configs::putAll);
+    formatOptions.getOptional(AWS_ENDPOINT).ifPresent(v -> configs.put(AWS_ENDPOINT.key(), v));
+    formatOptions.getOptional(REGISTRY_NAME).ifPresent(v -> configs.put(REGISTRY_NAME.key(), v));
+    formatOptions
+        .getOptional(SCHEMA_AUTO_REGISTRATION_SETTING)
+        .ifPresent(v -> configs.put(SCHEMA_AUTO_REGISTRATION_SETTING.key(), v));
+    formatOptions
+        .getOptional(SCHEMA_NAMING_GENERATION_CLASS)
+        .ifPresent(v -> configs.put(SCHEMA_NAMING_GENERATION_CLASS.key(), v));
+    formatOptions
+        .getOptional(SECONDARY_DESERIALIZER)
+        .ifPresent(v -> configs.put(SECONDARY_DESERIALIZER.key(), v));
+
+    return configs;
+  }
 }

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueSerializationSchema.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueSerializationSchema.java
@@ -1,0 +1,5 @@
+package io.epiphanous.flink.formats.avro.registry.glue.debezium;
+
+public class DebeziumAvroGlueSerializationSchema {
+    
+}

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueSerializationSchema.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueSerializationSchema.java
@@ -30,96 +30,95 @@ import io.epiphanous.flink.formats.avro.registry.glue.GlueAvroSerializationSchem
  */
 @Internal
 public class DebeziumAvroGlueSerializationSchema implements SerializationSchema<RowData> {
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    /** insert operation. */
-    private static final StringData OP_INSERT = StringData.fromString("c");
-    /** delete operation. */
-    private static final StringData OP_DELETE = StringData.fromString("d");
+  /** insert operation. */
+  private static final StringData OP_INSERT = StringData.fromString("c");
+  /** delete operation. */
+  private static final StringData OP_DELETE = StringData.fromString("d");
 
-    /** The deserializer to deserialize Debezium Avro data. */
-    private final AvroRowDataSerializationSchema avroSerializer;
+  /** The deserializer to deserialize Debezium Avro data. */
+  private final AvroRowDataSerializationSchema avroSerializer;
 
-    private transient GenericRowData outputReuse;
+  private transient GenericRowData outputReuse;
 
-    public DebeziumAvroGlueSerializationSchema(
-            RowType rowType,
-            String topic,
-            Map<String, Object> config) {
-        RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
-        Schema schema = AvroSchemaConverter.convertToSchema(debeziumAvroRowType);
-        SerializationSchema<GenericRecord> nestedSchema = GlueAvroSerializationSchema.forGeneric(schema, topic, config);
+  public DebeziumAvroGlueSerializationSchema(
+      RowType rowType,
+      String topic,
+      Map<String, Object> config) {
+    RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
+    Schema schema = AvroSchemaConverter.convertToSchema(debeziumAvroRowType);
+    SerializationSchema<GenericRecord> nestedSchema = GlueAvroSerializationSchema.forGeneric(schema, topic, config);
 
-        this.avroSerializer = new AvroRowDataSerializationSchema(
-            debeziumAvroRowType,
-            nestedSchema,
-            RowDataToAvroConverters.createConverter(debeziumAvroRowType)
-        );
+    this.avroSerializer = new AvroRowDataSerializationSchema(
+        debeziumAvroRowType,
+        nestedSchema,
+        RowDataToAvroConverters.createConverter(debeziumAvroRowType));
+  }
+
+  @VisibleForTesting
+  DebeziumAvroGlueSerializationSchema(AvroRowDataSerializationSchema avroSerializer) {
+    this.avroSerializer = avroSerializer;
+  }
+
+  @Override
+  public void open(InitializationContext context) throws Exception {
+    avroSerializer.open(context);
+    outputReuse = new GenericRowData(3);
+  }
+
+  @Override
+  public byte[] serialize(RowData rowData) {
+    RowKind rowKind = rowData.getRowKind();
+    try {
+      switch (rowKind) {
+        case INSERT:
+        case UPDATE_AFTER:
+          outputReuse.setField(0, null);
+          outputReuse.setField(1, rowData);
+          outputReuse.setField(2, OP_INSERT);
+          return avroSerializer.serialize(outputReuse);
+        case UPDATE_BEFORE:
+        case DELETE:
+          outputReuse.setField(0, rowData);
+          outputReuse.setField(1, null);
+          outputReuse.setField(2, OP_DELETE);
+          return avroSerializer.serialize(outputReuse);
+        default:
+          throw new UnsupportedOperationException(
+              format(
+                  "Unsupported operation '%s' for row kind.",
+                  rowData.getRowKind()));
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(format("Could not serialize row '%s'.", rowData), t);
     }
+  }
 
-    @VisibleForTesting
-    DebeziumAvroGlueSerializationSchema(AvroRowDataSerializationSchema avroSerializer) {
-        this.avroSerializer = avroSerializer;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DebeziumAvroGlueSerializationSchema that = (DebeziumAvroGlueSerializationSchema) o;
+    return Objects.equals(avroSerializer, that.avroSerializer);
+  }
 
-    @Override
-    public void open(InitializationContext context) throws Exception {
-        avroSerializer.open(context);
-        outputReuse = new GenericRowData(3);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(avroSerializer);
+  }
 
-    @Override
-    public byte[] serialize(RowData rowData) {
-        RowKind rowKind = rowData.getRowKind();
-        try {
-            switch (rowKind) {
-                case INSERT:
-                case UPDATE_AFTER:
-                    outputReuse.setField(0, null);
-                    outputReuse.setField(1, rowData);
-                    outputReuse.setField(2, OP_INSERT);
-                    return avroSerializer.serialize(outputReuse);
-                case UPDATE_BEFORE:
-                case DELETE:
-                    outputReuse.setField(0, rowData);
-                    outputReuse.setField(1, null);
-                    outputReuse.setField(2, OP_DELETE);
-                    return avroSerializer.serialize(outputReuse);
-                default:
-                    throw new UnsupportedOperationException(
-                            format(
-                                    "Unsupported operation '%s' for row kind.",
-                                    rowData.getRowKind()));
-            }
-        } catch (Throwable t) {
-            throw new RuntimeException(format("Could not serialize row '%s'.", rowData), t);
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DebeziumAvroGlueSerializationSchema that = (DebeziumAvroGlueSerializationSchema) o;
-        return Objects.equals(avroSerializer, that.avroSerializer);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(avroSerializer);
-    }
-
-    public static RowType createDebeziumAvroRowType(DataType dataType) {
-        // Debezium Avro contains other information, e.g. "source", "ts_ms"
-        // but we don't need them
-        return (RowType) DataTypes.ROW(
-                DataTypes.FIELD("before", dataType.nullable()),
-                DataTypes.FIELD("after", dataType.nullable()),
-                DataTypes.FIELD("op", DataTypes.STRING()))
-                .getLogicalType();
-    }
+  public static RowType createDebeziumAvroRowType(DataType dataType) {
+    // Debezium Avro contains other information, e.g. "source", "ts_ms"
+    // but we don't need them
+    return (RowType) DataTypes.ROW(
+        DataTypes.FIELD("before", dataType.nullable()),
+        DataTypes.FIELD("after", dataType.nullable()),
+        DataTypes.FIELD("op", DataTypes.STRING()))
+        .getLogicalType();
+  }
 }

--- a/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueSerializationSchema.java
+++ b/src/main/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueSerializationSchema.java
@@ -1,5 +1,125 @@
 package io.epiphanous.flink.formats.avro.registry.glue.debezium;
 
-public class DebeziumAvroGlueSerializationSchema {
-    
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.AvroRowDataSerializationSchema;
+import org.apache.flink.formats.avro.RowDataToAvroConverters;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
+import io.epiphanous.flink.formats.avro.registry.glue.GlueAvroSerializationSchema;
+
+/**
+ * Serialization schema from Flink Table/SQL internal data structure
+ * {@link RowData} to Debezium
+ * Avro.
+ */
+@Internal
+public class DebeziumAvroGlueSerializationSchema implements SerializationSchema<RowData> {
+    private static final long serialVersionUID = 1L;
+
+    /** insert operation. */
+    private static final StringData OP_INSERT = StringData.fromString("c");
+    /** delete operation. */
+    private static final StringData OP_DELETE = StringData.fromString("d");
+
+    /** The deserializer to deserialize Debezium Avro data. */
+    private final AvroRowDataSerializationSchema avroSerializer;
+
+    private transient GenericRowData outputReuse;
+
+    public DebeziumAvroGlueSerializationSchema(
+            RowType rowType,
+            String topic,
+            Map<String, Object> config) {
+        RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
+        Schema schema = AvroSchemaConverter.convertToSchema(debeziumAvroRowType);
+        SerializationSchema<GenericRecord> nestedSchema = GlueAvroSerializationSchema.forGeneric(schema, topic, config);
+
+        this.avroSerializer = new AvroRowDataSerializationSchema(
+            debeziumAvroRowType,
+            nestedSchema,
+            RowDataToAvroConverters.createConverter(debeziumAvroRowType)
+        );
+    }
+
+    @VisibleForTesting
+    DebeziumAvroGlueSerializationSchema(AvroRowDataSerializationSchema avroSerializer) {
+        this.avroSerializer = avroSerializer;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        avroSerializer.open(context);
+        outputReuse = new GenericRowData(3);
+    }
+
+    @Override
+    public byte[] serialize(RowData rowData) {
+        RowKind rowKind = rowData.getRowKind();
+        try {
+            switch (rowKind) {
+                case INSERT:
+                case UPDATE_AFTER:
+                    outputReuse.setField(0, null);
+                    outputReuse.setField(1, rowData);
+                    outputReuse.setField(2, OP_INSERT);
+                    return avroSerializer.serialize(outputReuse);
+                case UPDATE_BEFORE:
+                case DELETE:
+                    outputReuse.setField(0, rowData);
+                    outputReuse.setField(1, null);
+                    outputReuse.setField(2, OP_DELETE);
+                    return avroSerializer.serialize(outputReuse);
+                default:
+                    throw new UnsupportedOperationException(
+                            format(
+                                    "Unsupported operation '%s' for row kind.",
+                                    rowData.getRowKind()));
+            }
+        } catch (Throwable t) {
+            throw new RuntimeException(format("Could not serialize row '%s'.", rowData), t);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DebeziumAvroGlueSerializationSchema that = (DebeziumAvroGlueSerializationSchema) o;
+        return Objects.equals(avroSerializer, that.avroSerializer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(avroSerializer);
+    }
+
+    public static RowType createDebeziumAvroRowType(DataType dataType) {
+        // Debezium Avro contains other information, e.g. "source", "ts_ms"
+        // but we don't need them
+        return (RowType) DataTypes.ROW(
+                DataTypes.FIELD("before", dataType.nullable()),
+                DataTypes.FIELD("after", dataType.nullable()),
+                DataTypes.FIELD("op", DataTypes.STRING()))
+                .getLogicalType();
+    }
 }

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,1 +1,2 @@
 io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatFactory
+io.epiphanous.flink.formats.avro.registry.glue.debezium.DebeziumAvroGlueFormatFactory

--- a/src/test/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactoryTest.java
+++ b/src/test/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactoryTest.java
@@ -28,68 +28,68 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests for {@link DebeziumAvroGlueFormatFactory}. */
 class DebeziumAvroGlueFormatFactoryTest {
 
-    private static final ResolvedSchema SCHEMA = ResolvedSchema.of(
-            Column.physical("a", DataTypes.STRING()),
-            Column.physical("b", DataTypes.INT()),
-            Column.physical("c", DataTypes.BOOLEAN()));
+  private static final ResolvedSchema SCHEMA = ResolvedSchema.of(
+      Column.physical("a", DataTypes.STRING()),
+      Column.physical("b", DataTypes.INT()),
+      Column.physical("c", DataTypes.BOOLEAN()));
 
-    private static final RowType ROW_TYPE = (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
+  private static final RowType ROW_TYPE = (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
 
-    private static final String MY_SCHEMA_NAME = "debezium_test_schema";
+  private static final String MY_SCHEMA_NAME = "debezium_test_schema";
 
-    @Test
-    void testDeserializationSchema() {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(SCHEMA_NAME.key(), MY_SCHEMA_NAME);
-        configs.put(AWS_REGION.key(), AWS_REGION.defaultValue());
+  @Test
+  void testDeserializationSchema() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(SCHEMA_NAME.key(), MY_SCHEMA_NAME);
+    configs.put(AWS_REGION.key(), AWS_REGION.defaultValue());
 
-        final DebeziumAvroGlueDeserializationSchema expectedDeser = new DebeziumAvroGlueDeserializationSchema(
-                ROW_TYPE,
-                InternalTypeInfo.of(ROW_TYPE),
-                MY_SCHEMA_NAME,
-                configs);
-        final DynamicTableSource actualSource = FactoryMocks.createTableSource(SCHEMA, getDefaultOptions());
+    final DebeziumAvroGlueDeserializationSchema expectedDeser = new DebeziumAvroGlueDeserializationSchema(
+        ROW_TYPE,
+        InternalTypeInfo.of(ROW_TYPE),
+        MY_SCHEMA_NAME,
+        configs);
+    final DynamicTableSource actualSource = FactoryMocks.createTableSource(SCHEMA, getDefaultOptions());
 
-        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
+    assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
 
-        TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock = (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
-        DeserializationSchema<RowData> actualDeser = scanSourceMock.valueFormat.createRuntimeDecoder(
-                ScanRuntimeProviderContext.INSTANCE, SCHEMA.toPhysicalRowDataType());
+    TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock = (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+    DeserializationSchema<RowData> actualDeser = scanSourceMock.valueFormat.createRuntimeDecoder(
+        ScanRuntimeProviderContext.INSTANCE, SCHEMA.toPhysicalRowDataType());
 
-        assertThat(actualDeser).isEqualTo(expectedDeser);
-    }
+    assertThat(actualDeser).isEqualTo(expectedDeser);
+  }
 
-    @Test
-    void testSerializationSchema() {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(SCHEMA_NAME.key(), MY_SCHEMA_NAME);
-        configs.put(AWS_REGION.key(), AWS_REGION.defaultValue());
+  @Test
+  void testSerializationSchema() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(SCHEMA_NAME.key(), MY_SCHEMA_NAME);
+    configs.put(AWS_REGION.key(), AWS_REGION.defaultValue());
 
-        final SerializationSchema<RowData> expectedSer = new DebeziumAvroGlueSerializationSchema(
-                ROW_TYPE,
-                MY_SCHEMA_NAME,
-                configs);
-        final DynamicTableSink actualSink = FactoryMocks.createTableSink(SCHEMA, getDefaultOptions());
+    final SerializationSchema<RowData> expectedSer = new DebeziumAvroGlueSerializationSchema(
+        ROW_TYPE,
+        MY_SCHEMA_NAME,
+        configs);
+    final DynamicTableSink actualSink = FactoryMocks.createTableSink(SCHEMA, getDefaultOptions());
 
-        assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
+    assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
 
-        TestDynamicTableFactory.DynamicTableSinkMock sinkMock = (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+    TestDynamicTableFactory.DynamicTableSinkMock sinkMock = (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
 
-        SerializationSchema<RowData> actualSer = sinkMock.valueFormat.createRuntimeEncoder(null,
-                SCHEMA.toPhysicalRowDataType());
+    SerializationSchema<RowData> actualSer = sinkMock.valueFormat.createRuntimeEncoder(null,
+        SCHEMA.toPhysicalRowDataType());
 
-        assertThat(actualSer).isEqualTo(expectedSer);
-    }
+    assertThat(actualSer).isEqualTo(expectedSer);
+  }
 
-    @NotNull
-    private Map<String, String> getDefaultOptions() {
-        Map<String, String> options = new HashMap<>();
-        options.put("connector", TestDynamicTableFactory.IDENTIFIER);
-        options.put("target", "MyTarget");
-        options.put("buffer-size", "1000");
-        options.put("format", IDENTIFIER);
-        options.put("debezium-avro-glue.topic", "test-topic");
-        options.put("debezium-avro-glue.schemaName", MY_SCHEMA_NAME);
-        return options;
-    }
+  @NotNull
+  private Map<String, String> getDefaultOptions() {
+    Map<String, String> options = new HashMap<>();
+    options.put("connector", TestDynamicTableFactory.IDENTIFIER);
+    options.put("target", "MyTarget");
+    options.put("buffer-size", "1000");
+    options.put("format", IDENTIFIER);
+    options.put("debezium-avro-glue.topic", "test-topic");
+    options.put("debezium-avro-glue.schemaName", MY_SCHEMA_NAME);
+    return options;
+  }
 }

--- a/src/test/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactoryTest.java
+++ b/src/test/java/io/epiphanous/flink/formats/avro/registry/glue/debezium/DebeziumAvroGlueFormatFactoryTest.java
@@ -1,0 +1,95 @@
+package io.epiphanous.flink.formats.avro.registry.glue.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.TestDynamicTableFactory;
+import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.epiphanous.flink.formats.avro.registry.glue.AvroGlueFormatOptions.*;
+import static io.epiphanous.flink.formats.avro.registry.glue.debezium.DebeziumAvroGlueFormatFactory.IDENTIFIER;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DebeziumAvroGlueFormatFactory}. */
+class DebeziumAvroGlueFormatFactoryTest {
+
+    private static final ResolvedSchema SCHEMA = ResolvedSchema.of(
+            Column.physical("a", DataTypes.STRING()),
+            Column.physical("b", DataTypes.INT()),
+            Column.physical("c", DataTypes.BOOLEAN()));
+
+    private static final RowType ROW_TYPE = (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
+
+    private static final String MY_SCHEMA_NAME = "debezium_test_schema";
+
+    @Test
+    void testDeserializationSchema() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SCHEMA_NAME.key(), MY_SCHEMA_NAME);
+        configs.put(AWS_REGION.key(), AWS_REGION.defaultValue());
+
+        final DebeziumAvroGlueDeserializationSchema expectedDeser = new DebeziumAvroGlueDeserializationSchema(
+                ROW_TYPE,
+                InternalTypeInfo.of(ROW_TYPE),
+                MY_SCHEMA_NAME,
+                configs);
+        final DynamicTableSource actualSource = FactoryMocks.createTableSource(SCHEMA, getDefaultOptions());
+
+        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
+
+        TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock = (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+        DeserializationSchema<RowData> actualDeser = scanSourceMock.valueFormat.createRuntimeDecoder(
+                ScanRuntimeProviderContext.INSTANCE, SCHEMA.toPhysicalRowDataType());
+
+        assertThat(actualDeser).isEqualTo(expectedDeser);
+    }
+
+    @Test
+    void testSerializationSchema() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SCHEMA_NAME.key(), MY_SCHEMA_NAME);
+        configs.put(AWS_REGION.key(), AWS_REGION.defaultValue());
+
+        final SerializationSchema<RowData> expectedSer = new DebeziumAvroGlueSerializationSchema(
+                ROW_TYPE,
+                MY_SCHEMA_NAME,
+                configs);
+        final DynamicTableSink actualSink = FactoryMocks.createTableSink(SCHEMA, getDefaultOptions());
+
+        assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
+
+        TestDynamicTableFactory.DynamicTableSinkMock sinkMock = (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+
+        SerializationSchema<RowData> actualSer = sinkMock.valueFormat.createRuntimeEncoder(null,
+                SCHEMA.toPhysicalRowDataType());
+
+        assertThat(actualSer).isEqualTo(expectedSer);
+    }
+
+    @NotNull
+    private Map<String, String> getDefaultOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", TestDynamicTableFactory.IDENTIFIER);
+        options.put("target", "MyTarget");
+        options.put("buffer-size", "1000");
+        options.put("format", IDENTIFIER);
+        options.put("debezium-avro-glue.topic", "test-topic");
+        options.put("debezium-avro-glue.schemaName", MY_SCHEMA_NAME);
+        return options;
+    }
+}


### PR DESCRIPTION
This pull request introduces the `debezium-avro-glue` format support to Apache Flink. This format is an extension of `avro-glue` with the implementation of Debezium schema parsing similar to the [`debezium-avro-confluent` format](https://github.com/apache/flink/tree/master/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium).

Main changes:
- Added `DebeziumAvroGlueDeserializationSchema` class: This class is responsible for the deserialization of Avro messages in Debezium format.
- Added `DebeziumAvroGlueSerializationSchema`: This class handles the serialization of messages into the Debezium Avro format.
- Added tests for the new format.
- Documentation updates.

I tried to add a test verifying serialization and deserialization similar to [DebeziumAvroSerDeSchemaTest.java](https://github.com/apache/flink/blob/master/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java), but I encountered problems with mocking AWS Glue Schema Registry dependencies. Idea I'm exploring: [testGetSchemaAndDeserializedStream_withValidParams_succeeds](https://github.com/awslabs/aws-glue-schema-registry/blob/master/avro-flink-serde/src/test/java/com/amazonaws/services/schemaregistry/flink/avro/GlueSchemaRegistryInputStreamDeserializerTest.java#L112)