### PR TITLE
Update 'avro-glue.registry' to 'avro-glue.registry.name' in Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ CREATE TABLE user_created (
   'format'                   = 'avro-glue',
   'avro-glue.schemaName'     = 'org.example.avro.UserEvent'
   'avro-glue.region'         = 'us-east-1',
-  'avro-glue.registry'       = 'my-glue-registry',
+  'avro-glue.registry.name'  = 'my-glue-registry',
   'avro-glue.transport.name' = 'user_events'
 )
 ```
@@ -88,7 +88,7 @@ CREATE TABLE user_created (
   'format'                   = 'debezium-avro-glue',
   'avro-glue.schemaName'     = 'org.example.avro.UserEvent'
   'avro-glue.region'         = 'us-east-1',
-  'avro-glue.registry'       = 'my-glue-registry',
+  'avro-glue.registry.name'  = 'my-glue-registry',
   'avro-glue.transport.name' = 'user_events'
 )
 ```


### PR DESCRIPTION
Update 'avro-glue.registry' to 'avro-glue.registry.name' in Examples

Looks like we recently updated this in the table of options but missed the same update in the full examples ?